### PR TITLE
Update project to support zig compiler version 0.15.1. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .direnv
 zig-out
-zig-cache
+.zig-cache

--- a/build.zig
+++ b/build.zig
@@ -29,7 +29,7 @@ fn docsStep(
     const tar = b.addSystemCommand(&.{"sh"});
     tar.addArgs(&.{
         "-c",
-        b.fmt("cat {s} | tar --delete std builtin > {s}", .{ in_tar, out_tar }),
+        b.fmt("cat {s} | tar --delete std > {s}", .{ in_tar, out_tar }),
     });
 
     const mv = b.addSystemCommand(&.{ "mv", out_tar, in_tar });

--- a/build.zig
+++ b/build.zig
@@ -5,6 +5,7 @@ const std = @import("std");
 fn docsStep(
     b: *std.Build,
     target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
 ) *std.Build.Step {
     const dir = b.addInstallDirectory(.{
         .source_dir = b.addObject(.{
@@ -12,7 +13,7 @@ fn docsStep(
             .root_module = b.createModule(.{
                 .root_source_file = b.path("src/svg.zig"),
                 .target = target,
-                .optimize = .Debug,
+                .optimize = optimize,
             }),
         }).getEmittedDocs(),
         .install_dir = .prefix,
@@ -51,6 +52,7 @@ fn docsServeStep(b: *std.Build, docs_step: *std.Build.Step) *std.Build.Step {
 
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
     _ = b.addModule("svg", .{
         .root_source_file = b.path("src/svg.zig"),
     });
@@ -58,11 +60,11 @@ pub fn build(b: *std.Build) void {
         .root_module = b.createModule(.{
             .root_source_file = b.path("src/svg.zig"),
             .target = target,
-            .optimize = .Debug,
+            .optimize = optimize,
         }),
     }));
     b.step("test", "Run unit tests").dependOn(&tests.step);
-    const docs_step = docsStep(b, target);
+    const docs_step = docsStep(b, target, optimize);
     b.step("docs", "Generate documentation").dependOn(docs_step);
     b.step("docs-serve", "Serve documentation").dependOn(docsServeStep(b, docs_step));
 }

--- a/build.zig
+++ b/build.zig
@@ -53,15 +53,13 @@ fn docsServeStep(b: *std.Build, docs_step: *std.Build.Step) *std.Build.Step {
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
-    _ = b.addModule("svg", .{
+    const svg = b.addModule("svg", .{
         .root_source_file = b.path("src/svg.zig"),
+        .target = target,
+        .optimize = optimize,
     });
     const tests = b.addRunArtifact(b.addTest(.{
-        .root_module = b.createModule(.{
-            .root_source_file = b.path("src/svg.zig"),
-            .target = target,
-            .optimize = optimize,
-        }),
+        .root_module = svg,
     }));
     b.step("test", "Run unit tests").dependOn(&tests.step);
     const docs_step = docsStep(b, target, optimize);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 //   Copyright © 2024 Chris Marchesi
 .{
-    .name = "zig-svg",
+    .name = .zigsvg,
     .version = "0.1.0",
     .minimum_zig_version = "0.15.1",
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,6 +3,7 @@
 .{
     .name = "zig-svg",
     .version = "0.1.0",
+    .minimum_zig_version = "0.15.1",
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,6 +3,7 @@
 .{
     .name = .zigsvg,
     .version = "0.1.0",
+    .fingerprint = 0xd5aca900c030faaf,
     .minimum_zig_version = "0.15.1",
     .paths = .{
         "build.zig",


### PR DESCRIPTION
This pull request makes it possible to `zig fetch --save` repo into another project with a `mininum_zig_version` of 0.15.1. 

Main blockers where:

- The format of build.zig.zon has changed since this repo was last updated.
- Minor changes in build.zig were required to make both library and docs build.
- API of std.ArrayList has also changed, hence svg.zig required adjusting.

Things checked before submitting this PR:

- All tests when running `zig test src/svg.zig` pass.
- Running `zig docs-serve` build docs and serves documentation at `localhost:8000`.
- Library can be added into another one using `zig fetch` command and `svg` module can be accessed.